### PR TITLE
Fix node type assignment

### DIFF
--- a/stargate_x/graph.py
+++ b/stargate_x/graph.py
@@ -175,10 +175,22 @@ class ReactomeGraph(nx.MultiDiGraph):
             try:
                 source = dict(record['source']['data'])
                 target = dict(record['target']['data'])
+
+                # bipartite networkx convention
+                source["bipartite"] = (
+                    EVENT if "Event" in record["source"]["labels"]
+                    else ENTITY
+                )
+                target["bipartite"] = (
+                    EVENT if "Event" in record["target"]["labels"]
+                    else ENTITY
+                )
+
                 relationship = {
                     **dict(record['relationship']['data']),
                     'type': record['relationship']['type']
                 }
+
             except (ValueError, TypeError, KeyError):
                 continue
 
@@ -189,23 +201,12 @@ class ReactomeGraph(nx.MultiDiGraph):
                 'positiveRegulator',
                 'negativeRegulator'
             ]:
-                t = {**source}
-                source = {**target}
-                target = t
-
-            # bipartite networkx convention
-            source['bipartite'] = (
-                EVENT if 'Event' in record['source']['labels']
-                else ENTITY)
+                source, target = target, source
 
             if relationship['type'] == 'referenceEntity':
                 source['referenceEntity'] = target
                 nodes[source['stId']] = source
             else:
-                target['bipartite'] = (
-                    EVENT if 'Event' in record['target']['labels']
-                    else ENTITY)
-
                 nodes[source['stId']] = source
                 nodes[target['stId']] = target
                 edges.append((source['stId'], target['stId'], relationship))


### PR DESCRIPTION
This commit fixes an issue with the reversing of the edge direction when building the graph from the neo4j database.

The new source gets assigned the labels of the old source. This leads to nodes being marked as the wrong type (event <> entity). The patch fixes this behavior.

To illustrate the issue: Many entity nodes contain the word "binds", which is normally found in event type nodes.
```
graph = ReactomeGraph.build('Homo sapiens', options={"neo4j_uri": "bolt://localhost:7687"})
nodes = [n for n in graph.entity_nodes if 'binds' in graph.nodes[n]['displayName']]
print(len(nodes))
```
The above prints 1591 before the fix and 0 after.